### PR TITLE
Support custom validators

### DIFF
--- a/examples/validators.py
+++ b/examples/validators.py
@@ -1,15 +1,11 @@
 from typing import List
 
 import click
-import typer
 from pydantic import BaseModel
 
 from pydanclick import from_pydantic
 
-app = typer.Typer()
 
-
-@app.command()
 class CustomSubModel(BaseModel):
     sub_values: List[str]
 

--- a/examples/validators.py
+++ b/examples/validators.py
@@ -1,0 +1,31 @@
+from typing import List
+
+import click
+import typer
+from pydantic import BaseModel
+
+from pydanclick import from_pydantic
+
+app = typer.Typer()
+
+
+@app.command()
+class CustomSubModel(BaseModel):
+    sub_values: List[str]
+
+
+class CustomModel(BaseModel):
+    values: List[int]
+    sub_model: CustomSubModel
+
+
+@click.command()
+@from_pydantic(
+    CustomModel, validators={"values": lambda x: map(int, x.split(",")), "sub_model.sub_values": lambda x: x.split(",")}
+)
+def test(custom_model: CustomModel):
+    click.echo(custom_model.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    test()

--- a/pydanclick/main.py
+++ b/pydanclick/main.py
@@ -22,6 +22,7 @@ def from_pydantic(
     parse_docstring: bool = True,
     docstring_style: Literal["google", "numpy", "sphinx"] = "google",
     extra_options: Optional[Dict[str, _ParameterKwargs]] = None,
+    validators: Optional[Dict[str, Callable]] = None,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator to add fields from a Pydantic model as options to a Click command.
 
@@ -37,6 +38,7 @@ def from_pydantic(
             documentation to the Click `help` option
         docstring_style: style of the docstring (`google`, `numpy` or `sphinx`). Ignored if `parse_docstring` is False
         extra_options: a mapping from field names to a dictionary of options passed to the `click.option()` function
+        validators: a mapping from field names to a callable used to validate command line values
 
     Returns:
         a decorator that adds options to a function
@@ -48,6 +50,8 @@ def from_pydantic(
     else:
         model = __var_or_model
         variable_name = camel_case_to_snake_case(model.__name__)
+    if validators is None:
+        validators = {}
     options, validator = convert_to_click(
         model,
         exclude=exclude,
@@ -57,6 +61,7 @@ def from_pydantic(
         parse_docstring=parse_docstring,
         docstring_style=docstring_style,
         extra_options=extra_options,
+        validators=validators,
     )
 
     def wrapper(f: Callable[..., T]) -> Callable[..., T]:

--- a/pydanclick/model/field_collection.py
+++ b/pydanclick/model/field_collection.py
@@ -133,14 +133,14 @@ def _collect_fields(
                 )
         # TODO: exclude base models from the union
         dotted_name = DottedFieldName(".".join(parents))
-        serializer = validators.get(dotted_name, None)
+        validator = validators.get(dotted_name, None)
         yield _Field(
             name=name,
             dotted_name=dotted_name,
             parents=parents,
             field_info=obj,
             documentation=documentation,
-            validator=serializer,
+            validator=validator,
         )
     else:
         raise TypeError(f"Can't process {type(obj)}: {obj} is neither a `BaseModel`, nor a `FieldInfo`")

--- a/pydanclick/model/field_conversion.py
+++ b/pydanclick/model/field_conversion.py
@@ -55,6 +55,7 @@ def convert_fields_to_options(
             documentation=field.field_info.description or field.documentation,
             short_name=shorten.get(field.dotted_name, None),
             option_kwargs=extra_options.get(field.dotted_name, {}),
+            validator=field.validator,
         )
         options.append(option)
         qualified_names[argument_name] = field.dotted_name
@@ -139,6 +140,7 @@ def _get_option_from_field(
     documentation: Optional[str] = None,
     short_name: Optional[str] = None,
     option_kwargs: Optional[_ParameterKwargs] = None,
+    validator: Optional[Callable] = None,
 ) -> click.Option:
     """Convert a Pydantic field to a Click option.
 
@@ -150,6 +152,7 @@ def _get_option_from_field(
         documentation: help string for the option
         short_name: short name of the option (one dash and one letter)
         option_kwargs: extra options to pass to `click.option`
+        validator: callable to validate command line value
 
     Returns:
         `click.Option` object
@@ -158,7 +161,7 @@ def _get_option_from_field(
     if short_name is not None:
         param_decls.append(short_name)
     kwargs: _ParameterKwargs = {
-        "type": _get_type_from_field(field_info),
+        "type": _get_type_from_field(field_info, validator),
         "default": _get_default_value_from_field(field_info),
         "required": field_info.is_required(),
         "help": documentation,

--- a/pydanclick/model/model_conversion.py
+++ b/pydanclick/model/model_conversion.py
@@ -17,6 +17,7 @@ M = TypeVar("M", bound=BaseModel)
 
 def convert_to_click(
     model: Type[M],
+    validators: Dict[str, Callable],
     *,
     exclude: Sequence[str] = (),
     rename: Optional[Dict[str, str]] = None,
@@ -56,6 +57,7 @@ def convert_to_click(
         docstring_style: docstring style of the model. Only used if `parse_docstring=True`
         extra_options: extra options to pass to `click.Option` for specific fields, as a mapping from dotted field names
             to option dictionary
+        validators: a mapping from field names to a callable used to validate command line values
 
     Returns:
         a pair `(options, validate)` where `options` is the list of Click options extracted from the model, and
@@ -68,6 +70,7 @@ def convert_to_click(
         excluded_fields=cast(Set[DottedFieldName], set(exclude)),
         docstring_style=docstring_style,
         parse_docstring=parse_docstring,
+        validators=validators,
     )
     qualified_names, options = convert_fields_to_options(
         fields,

--- a/pydanclick/model/validation.py
+++ b/pydanclick/model/validation.py
@@ -8,7 +8,7 @@ Validation involves the following steps:
 - pass the nested representation to the `model_validate` method of the Pydantic model
 """
 
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Optional, Type
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
@@ -21,7 +21,10 @@ K = TypeVar("K", bound=str)
 
 
 def model_validate_kwargs(
-    kwargs: Dict[ArgumentName, Any], model: Type[M], qualified_names: Dict[ArgumentName, DottedFieldName]
+    kwargs: Dict[ArgumentName, Any],
+    model: Type[M],
+    qualified_names: Dict[ArgumentName, DottedFieldName],
+    validators: Optional[Dict[str, Callable]] = None,
 ) -> M:
     """Instantiate `model` for keyword arguments.
 


### PR DESCRIPTION
Draft PR to support custom validators for custom types.
Running `python examples/validators.py --values "1,2,3" --sub-model-sub-values "a,b,c"` outputs the following:
```bash
{
  "values": [
    1,
    2,
    3
  ],
  "sub_model": {
    "sub_values": [
      "a",
      "b",
      "c"
    ]
  }
}
```